### PR TITLE
fix: react fast refresh by reordering Vite React preamble script first

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,6 +25,17 @@ export function isObject(value: unknown): value is Record<string, unknown> {
 function getViteScripts() {
   const entries: string[] = []
 
+  entries.push('<script type="module" src="/@vite/client"></script>')
+
+  const isUsingReact = resolvedConfig.plugins.find(({ name }) => name === 'vite:react-refresh')
+  if (isUsingReact) {
+    entries.push(`
+<script type="module">
+  ${viteReact.preambleCode.replace('__BASE__', resolvedConfig.base)}
+</script>
+    `)
+  }
+
   for (const source of bundleEntries) {
     if (/\.(js|ts)x?/.test(source)) {
       entries.push(`<script type="module" src="/${source}"></script>`)
@@ -33,22 +44,7 @@ function getViteScripts() {
     }
   }
 
-  let scripts = `
-<script type="module" src="/@vite/client"></script>
-${entries.join('\n')}
-`
-
-  const isUsingReact = resolvedConfig.plugins.find(({ name }) => name === 'vite:react-refresh')
-
-  if (isUsingReact) {
-    scripts += `
-<script type="module">
-  ${viteReact.preambleCode.replace('__BASE__', resolvedConfig.base)}
-</script>
-    `
-  }
-
-  return scripts
+  return entries.join('\n')
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix React fast refresh script injection

Fixes #10 

### Additional context

Reorder injection to avoid error
```
Uncaught Error: @vitejs/plugin-react can't detect preamble. Something is wrong. See https://github.com/vitejs/vite-plugin-react/pull/11#discussion_r430879201
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/aem-vite/vite-aem-plugin/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Process](https://github.com/aem-vite/vite-aem-plugin/blob/main/.github/contributing.md#pull-request-process) and follow the [Commit Convention](https://github.com/aem-vite/vite-aem-plugin/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
