### PR TITLE
feat: add support for custom key format expressions #14

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,18 @@ export interface PluginOptions {
   contentPaths: string[]
 
   /**
+   * A list of key format expressions to use when matching ClientLibs on a page.
+   *
+   * @example
+   * ```js
+   * {
+   *   keyFormatExpressions: ['(\\w{32}(.min)?']
+   * }
+   * ```
+   */
+  keyFormatExpressions?: string[]
+
+  /**
    * The public path in AEM where your ClientLibs are stored.
    *
    * @example


### PR DESCRIPTION
Introduces support for custom key format expressions that can be used to find non-standard ClientLibs in a page.

Closes: https://github.com/aem-vite/vite-aem-plugin/issues/14